### PR TITLE
can't change message for regon validation

### DIFF
--- a/lib/common_numbers_rails/nip_validator.rb
+++ b/lib/common_numbers_rails/nip_validator.rb
@@ -5,7 +5,7 @@ class NipValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     @message = options[:message] || "invalid format"
-    record.errors[attribute] << @message unless CommonNumbers::Polish::Nip.new(value).valid?
+    record.errors.add(attribute,  @message) unless CommonNumbers::Polish::Nip.new(value).valid?
   end
 
 end

--- a/lib/common_numbers_rails/regon_validator.rb
+++ b/lib/common_numbers_rails/regon_validator.rb
@@ -5,7 +5,7 @@ class RegonValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     @message = options[:message] || "invalid format"
-    record.errors[attribute] << "invalid format" unless CommonNumbers::Polish::Regon.new(value).valid?
+    record.errors.add(attribute,  @message) unless CommonNumbers::Polish::Regon.new(value).valid?
   end
 
 end


### PR DESCRIPTION
For nip validation I can set a error message but for regon validation error message is always: "invalid format"
