### PR TITLE
Bump gem version to reflect custom message fixes

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use ruby-1.9.2-p180@nip_rails

--- a/lib/common_numbers_rails/version.rb
+++ b/lib/common_numbers_rails/version.rb
@@ -1,3 +1,3 @@
 module CommonNumbersRails
-  VERSION = "0.1.4"
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Bumped version of the gem in necessary to reflect the fix related to inability to set a custom validation messages.
